### PR TITLE
Add responsive layout with header and useful links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,25 @@
 import { useState } from "react";
+import Header from "./components/Header";
 import PriceForm from "./components/PriceForm";
 import PriceList from "./components/PriceList";
 import MapView from "./components/MapView";
+import UsefulLinks from "./components/UsefulLinks";
 
 export default function App() {
   const [refresh, setRefresh] = useState(false);
 
   return (
-    <div className="max-w-6xl mx-auto p-4 space-y-6">
-      <h1 className="text-3xl font-bold text-center text-indigo-700 mb-6">
-        💉 Mounjaro Price Tracker
-      </h1>
-      <PriceForm onNewPrice={() => setRefresh((f) => !f)} />
-      <PriceList key={refresh} />
-      <MapView key={refresh} />
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 max-w-6xl mx-auto p-4 space-y-6">
+        <div className="grid gap-4 md:grid-cols-3">
+          <PriceForm onNewPrice={() => setRefresh((f) => !f)} />
+          <PriceList key={refresh} />
+          <MapView key={refresh} />
+        </div>
+        <UsefulLinks />
+      </main>
     </div>
   );
 }
+

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import logo from "../assets/react.svg";
+
+export default function Header() {
+  const [open, setOpen] = useState(false);
+
+  const classes = [
+    "md:flex md:space-x-4",
+    "absolute md:static right-0 mt-2 md:mt-0",
+    "bg-indigo-700 md:bg-transparent p-4 md:p-0",
+    "rounded md:rounded-none shadow md:shadow-none",
+    open ? "block" : "hidden",
+    "md:block",
+  ].join(" ");
+
+  return (
+    <header className="bg-indigo-700 text-white">
+      <div className="max-w-6xl mx-auto flex items-center justify-between p-4">
+        <div className="flex items-center space-x-2">
+          <img src={logo} alt="Logo" className="h-8 w-8" />
+          <span className="font-bold text-lg">Mounjaro Tracker</span>
+        </div>
+        <nav className="relative">
+          <button
+            className="md:hidden"
+            onClick={() => setOpen((o) => !o)}
+            aria-label="Toggle navigation"
+          >
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+          <ul className={classes}>
+            <li>
+              <a href="#" className="block py-1 hover:underline">
+                Home
+              </a>
+            </li>
+            <li>
+              <a
+                href="#useful-links"
+                className="block py-1 hover:underline"
+              >
+                Useful Links
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}
+

--- a/src/components/UsefulLinks.jsx
+++ b/src/components/UsefulLinks.jsx
@@ -1,0 +1,30 @@
+export default function UsefulLinks() {
+  return (
+    <section id="useful-links" className="mt-8">
+      <h2 className="text-xl font-semibold mb-4">Useful Links</h2>
+      <ul className="space-y-2">
+        <li>
+          <a
+            href="https://www.amazon.com/s?k=mounjaro&tag=affiliate"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-indigo-600 underline"
+          >
+            Amazon Products
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www.youtube.com/@EliLillyandCompany"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-indigo-600 underline"
+          >
+            Eli Lilly on YouTube
+          </a>
+        </li>
+      </ul>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add responsive header with logo and mobile hamburger nav
- arrange form, list, and map into three-column layout
- include useful links section for Amazon products and Eli Lilly videos

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68949705aa9c8331a9bf315c239b41bf